### PR TITLE
Resolve the getrandom  cyclic dependencies problem

### DIFF
--- a/support/enhance-wasm/Cargo.toml
+++ b/support/enhance-wasm/Cargo.toml
@@ -28,7 +28,7 @@ num-bigint = { version = "0.4.3" }
 # wasm
 console_error_panic_hook = { version = "0" }
 wee_alloc = { version = "0" }
-wasm-bindgen = { version = "0", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0" }
 wasm-bindgen-futures = { version = "0" }
 serde-wasm-bindgen = { version = "0" }
 js-sys = { version = "0" }
@@ -45,14 +45,17 @@ web-sys = { version = "0", features = [
     'Storage',
 ] }
 wasm-bindgen-test = { version = "0" }
-#getrandom = { version = "^0.2", features = ["js"] }
+
+# see: https://github.com/rust-random/getrandom/issues/231
+# see: https://github.com/rustwasm/wasm-bindgen/pull/3031
+getrandom = { version = "^0.2", features = ["js"]}
 
 # TODO
 rand = { version = "0.8" }
 rand_core = { version = "0.6" }
 
 #[cfg(not(target_arch = "wasm32"))]
-serde_json = { workspace = true}
+serde_json = { workspace = true }
 
 [dev-dependencies]
 wasm-bindgen-test = { version = "0" }


### PR DESCRIPTION
Remove crate `wasm-bindgen`'s feature `serde-serialize`, which has been deprecated
- about cyclic dependencies
https://github.com/rust-random/getrandom/issues/231
- about deprecating feature "serde-serialize"
https://github.com/rustwasm/wasm-bindgen/pull/3031