### PR TITLE
global: Update tardis beta 11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,6 @@ fancy-regex = { version = "0" }
 run_script = { version = "0.10" }
 
 # tardis
-tardis = { version = "=0.1.0-beta.10" }
+tardis = { version = "=0.1.0-beta.11" }
 # tardis = { paths = "../tardis/tardis" }
 # tardis = { git = "https://github.com/ideal-world/tardis.git" }

--- a/basic/src/spi/api/spi_ci_bs_api.rs
+++ b/basic/src/spi/api/spi_ci_bs_api.rs
@@ -10,7 +10,7 @@ use crate::rbum::serv::rbum_item_serv::RbumItemCrudOperation;
 use crate::spi::dto::spi_bs_dto::{SpiBsAddReq, SpiBsDetailResp, SpiBsFilterReq, SpiBsModifyReq, SpiBsSummaryResp};
 use crate::spi::serv::spi_bs_serv::SpiBsServ;
 use crate::TardisFunInstExtractor;
-
+#[derive(Default, Clone, Copy, Debug)]
 pub struct SpiCiBsApi;
 
 /// Interface Console Backend Service API

--- a/gateway/test/src/http_backend.rs
+++ b/gateway/test/src/http_backend.rs
@@ -22,7 +22,7 @@ pub struct TestAddReq {
     pub description: String,
     pub done: bool,
 }
-
+#[derive(Clone)]
 pub struct TestApi;
 
 #[poem_openapi::OpenApi(prefix_path = "/echo")]

--- a/gateway/test/src/main.rs
+++ b/gateway/test/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> TardisResult<()> {
     env::set_var("RUST_LOG", "info,tardis=trace");
     // Prepare
     log::info!("Init http server");
-    tokio::spawn(async move { start_serv().await });
+    start_serv().await?;
     log::info!("Init gateway server");
     let docker = testcontainers::clients::Cli::default();
     let (gateway_url, _life_hold) = init_apisix::init(&docker).await?;
@@ -86,7 +86,7 @@ async fn main() -> TardisResult<()> {
 
     Ok(())
 }
-
+#[derive(Clone, Default)]
 pub struct AuthApi;
 
 /// Auth API
@@ -169,7 +169,7 @@ async fn start_serv() -> TardisResult<()> {
         },
     })
     .await?;
-    TardisFuns::web_server().add_module("auth", AuthApi, None).await.add_module("test", TestApi, None).await.start().await
+    TardisFuns::web_server().add_module("auth", AuthApi).await.add_module("test", TestApi).await.start().await
 }
 
 #[derive(poem_openapi::Object, Serialize, Deserialize, Debug)]

--- a/middleware/event/src/api/event_listener_api.rs
+++ b/middleware/event/src/api/event_listener_api.rs
@@ -7,7 +7,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisResp, Void};
 
 use crate::dto::event_dto::{EventListenerRegisterReq, EventListenerRegisterResp};
 use crate::serv::event_listener_serv;
-
+#[derive(Clone)]
 pub struct EventListenerApi;
 
 /// Event Listener API

--- a/middleware/event/src/api/event_proc_api.rs
+++ b/middleware/event/src/api/event_proc_api.rs
@@ -5,7 +5,7 @@ use tardis::web::poem_openapi;
 use tardis::web::poem_openapi::param::{Path, Query};
 
 use crate::serv::event_proc_serv;
-
+#[derive(Clone)]
 pub struct EventProcApi;
 
 /// Event Process API

--- a/middleware/event/src/api/event_topic_api.rs
+++ b/middleware/event/src/api/event_topic_api.rs
@@ -10,7 +10,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp, Void};
 
 use crate::dto::event_dto::{EventTopicAddOrModifyReq, EventTopicFilterReq, EventTopicInfoResp};
 use crate::serv::event_topic_serv::EventDefServ;
-
+#[derive(Clone)]
 pub struct EventTopicApi;
 
 /// Event Topic API

--- a/middleware/event/src/event_initializer.rs
+++ b/middleware/event/src/event_initializer.rs
@@ -83,7 +83,6 @@ async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
         .add_module(
             DOMAIN_CODE,
             (event_topic_api::EventTopicApi, event_proc_api::EventProcApi, event_listener_api::EventListenerApi),
-            None,
         )
         .await;
     Ok(())

--- a/middleware/flow/src/api/cc/flow_cc_inst_api.rs
+++ b/middleware/flow/src/api/cc/flow_cc_inst_api.rs
@@ -11,7 +11,7 @@ use crate::dto::flow_inst_dto::{
 use crate::dto::flow_model_dto::FlowTagKind;
 use crate::flow_constants;
 use crate::serv::flow_inst_serv::FlowInstServ;
-
+#[derive(Clone)]
 pub struct FlowCcInstApi;
 
 /// Flow instance process API

--- a/middleware/flow/src/api/cc/flow_cc_model_api.rs
+++ b/middleware/flow/src/api/cc/flow_cc_model_api.rs
@@ -15,7 +15,7 @@ use crate::dto::flow_model_dto::{
 use crate::flow_constants;
 use crate::serv::flow_model_serv::FlowModelServ;
 use crate::serv::flow_rel_serv::FlowRelKind;
-
+#[derive(Clone)]
 pub struct FlowCcModelApi;
 
 /// Flow model process API

--- a/middleware/flow/src/api/cc/flow_cc_state_api.rs
+++ b/middleware/flow/src/api/cc/flow_cc_state_api.rs
@@ -11,7 +11,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp, Void};
 use crate::dto::flow_state_dto::{FlowStateAddReq, FlowStateDetailResp, FlowStateFilterReq, FlowStateKind, FlowStateModifyReq, FlowStateSummaryResp, FlowSysStateKind};
 use crate::flow_constants;
 use crate::serv::flow_state_serv::FlowStateServ;
-
+#[derive(Clone)]
 pub struct FlowCcStateApi;
 
 /// Flow state process API

--- a/middleware/flow/src/flow_initializer.rs
+++ b/middleware/flow/src/flow_initializer.rs
@@ -36,7 +36,6 @@ async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
         .add_module(
             flow_constants::DOMAIN_CODE,
             (flow_cc_state_api::FlowCcStateApi, flow_cc_model_api::FlowCcModelApi, flow_cc_inst_api::FlowCcInstApi),
-            Vec::new(),
         )
         .await;
     Ok(())

--- a/middleware/flow/src/serv/flow_inst_serv.rs
+++ b/middleware/flow/src/serv/flow_inst_serv.rs
@@ -538,9 +538,10 @@ impl FlowInstServ {
             })
             .filter(|model_transition| {
                 if !model_transition.guard_by_creator
-                && model_transition.guard_by_spec_account_ids.is_empty()
-                && model_transition.guard_by_spec_role_ids.is_empty()
-                && !model_transition.guard_by_his_operators {
+                    && model_transition.guard_by_spec_account_ids.is_empty()
+                    && model_transition.guard_by_spec_role_ids.is_empty()
+                    && !model_transition.guard_by_his_operators
+                {
                     return true;
                 }
                 if model_transition.guard_by_creator && !(flow_inst.create_ctx.own_paths != ctx.own_paths || flow_inst.create_ctx.owner != ctx.owner) {

--- a/middleware/schedule/src/api/ci/schedule_ci_job_api.rs
+++ b/middleware/schedule/src/api/ci/schedule_ci_job_api.rs
@@ -11,6 +11,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp, Void};
 use crate::dto::schedule_job_dto::{ScheduleJobAddOrModifyReq, ScheduleJobInfoResp, ScheduleTaskInfoResp};
 use crate::serv::schedule_job_serv;
 
+#[derive(Clone)]
 pub struct ScheduleCiJobApi;
 
 /// Interface Console schedule API

--- a/middleware/schedule/src/schedule_initializer.rs
+++ b/middleware/schedule/src/schedule_initializer.rs
@@ -17,7 +17,7 @@ pub async fn init(web_server: &TardisWebServer) -> TardisResult<()> {
 }
 
 async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
-    web_server.add_module(DOMAIN_CODE, schedule_ci_job_api::ScheduleCiJobApi, None).await;
+    web_server.add_module(DOMAIN_CODE, schedule_ci_job_api::ScheduleCiJobApi).await;
     Ok(())
 }
 

--- a/middleware/schedule/tests/test_common.rs
+++ b/middleware/schedule/tests/test_common.rs
@@ -16,7 +16,6 @@ use bios_spi_kv::kv_initializer;
 use bios_spi_log::log_initializer;
 use tardis::{
     basic::{dto::TardisContext, field::TrimString, result::TardisResult},
-    tokio,
     web::{
         poem_openapi,
         web_resp::{TardisApiResult, TardisResp, Void},
@@ -28,7 +27,7 @@ pub struct TestEnv {
     pub counter: Arc<AtomicUsize>,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct CallbackApi {
     counter: Arc<AtomicUsize>,
 }
@@ -59,7 +58,7 @@ pub async fn mock_webserver() -> TardisResult<Arc<AtomicUsize>> {
     println!("mock logger started");
     let cb_api = CallbackApi::default();
     let cb_counter = Arc::clone(&cb_api.counter);
-    tokio::spawn(TardisFuns::web_server().add_route(cb_api).await.start());
+    TardisFuns::web_server().add_route(cb_api).await.start().await?;
     Ok(cb_counter)
 }
 #[allow(dead_code)]

--- a/services/bios-all/src/main.rs
+++ b/services/bios-all/src/main.rs
@@ -14,5 +14,7 @@ async fn main() -> TardisResult<()> {
     TardisFuns::init(Some("config")).await?;
     let web_server = TardisFuns::web_server();
     initializer::init(web_server).await?;
-    web_server.start().await
+    web_server.start().await?;
+    web_server.await;
+    Ok(())
 }

--- a/services/spi-all/src/main.rs
+++ b/services/spi-all/src/main.rs
@@ -14,5 +14,7 @@ async fn main() -> TardisResult<()> {
     TardisFuns::init(Some("config")).await?;
     let web_server = TardisFuns::web_server();
     initializer::init(web_server).await?;
-    web_server.start().await
+    web_server.start().await?;
+    web_server.await;
+    Ok(())
 }

--- a/spi/spi-cache/src/api/ci/cache_ci_proc_api.rs
+++ b/spi/spi-cache/src/api/ci/cache_ci_proc_api.rs
@@ -8,7 +8,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisResp, Void};
 
 use crate::dto::cache_proc_dto::{ExpReq, KIncrReq, KReq, KbRagngeReq, KbReq, KbvReq, KfIncrReq, KfReq, KfvReq, KvReq, KvWithExReq};
 use crate::serv::cache_proc_serv;
-
+#[derive(Clone)]
 pub struct CacheCiProcApi;
 
 /// Interface Console Cache API

--- a/spi/spi-cache/src/cache_initializer.rs
+++ b/spi/spi-cache/src/cache_initializer.rs
@@ -28,7 +28,7 @@ async fn init_db(funs: &TardisFunsInst, ctx: &TardisContext) -> TardisResult<()>
 }
 
 async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
-    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, cache_ci_proc_api::CacheCiProcApi), None).await;
+    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, cache_ci_proc_api::CacheCiProcApi)).await;
     Ok(())
 }
 

--- a/spi/spi-conf/src/api.rs
+++ b/spi/spi-conf/src/api.rs
@@ -8,8 +8,6 @@ mod nacos;
 use crate::conf_constants;
 use nacos::*;
 
-pub type ConfApi = (ConfCiApi, ConfNacosApi);
-
 pub async fn init_api(web_server: &TardisWebServer) {
     web_server.add_module(conf_constants::DOMAIN_CODE, (SpiCiBsApi, ConfCiApi::default())).await;
     let mut nacos_module = WebServerModule::new(ConfNacosApi::default());

--- a/spi/spi-conf/src/api.rs
+++ b/spi/spi-conf/src/api.rs
@@ -1,5 +1,5 @@
 use bios_basic::spi::api::spi_ci_bs_api::SpiCiBsApi;
-use tardis::web::web_server::TardisWebServer;
+use tardis::web::web_server::{TardisWebServer, WebServerModule};
 
 mod ci;
 use ci::*;
@@ -11,5 +11,8 @@ use nacos::*;
 pub type ConfApi = (ConfCiApi, ConfNacosApi);
 
 pub async fn init_api(web_server: &TardisWebServer) {
-    web_server.add_module(conf_constants::DOMAIN_CODE, (SpiCiBsApi, ConfApi::default()), None).await;
+    web_server.add_module(conf_constants::DOMAIN_CODE, (SpiCiBsApi, ConfCiApi::default())).await;
+    let mut nacos_module = WebServerModule::new(ConfNacosApi::default());
+    nacos_module.options.set_uniform_error(false);
+    web_server.add_module(&format!("{domain}-nacos", domain = conf_constants::DOMAIN_CODE), nacos_module).await;
 }

--- a/spi/spi-conf/src/api/ci/conf_auth.rs
+++ b/spi/spi-conf/src/api/ci/conf_auth.rs
@@ -7,7 +7,8 @@ use tardis::web::{
 use crate::dto::conf_auth_dto::*;
 use crate::serv::*;
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy, Debug)]
+
 pub struct ConfCiAuthApi;
 
 #[poem_openapi::OpenApi(prefix_path = "/ci/auth", tag = "bios_basic::ApiTag::Interface")]

--- a/spi/spi-conf/src/api/ci/conf_config_service_api.rs
+++ b/spi/spi-conf/src/api/ci/conf_config_service_api.rs
@@ -11,7 +11,7 @@ use tardis::{
 use crate::dto::{conf_config_dto::*, conf_namespace_dto::*};
 use crate::{conf_constants::error, serv::*};
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct ConfCiConfigServiceApi;
 
 /// Interface Console config server API

--- a/spi/spi-conf/src/api/ci/conf_namespace_api.rs
+++ b/spi/spi-conf/src/api/ci/conf_namespace_api.rs
@@ -6,7 +6,8 @@ use tardis::web::{
 
 use crate::dto::conf_namespace_dto::*;
 use crate::serv::*;
-#[derive(Default)]
+#[derive(Default, Clone, Copy, Debug)]
+
 pub struct ConfCiNamespaceApi;
 
 /// Interface Console config server API

--- a/spi/spi-conf/src/api/nacos.rs
+++ b/spi/spi-conf/src/api/nacos.rs
@@ -1,4 +1,7 @@
 mod v1;
+mod v2;
 pub use self::v1::*;
+mod v2;
+pub use self::v2::*;
 
-pub type ConfNacosApi = ConfNacosV1Api;
+pub type ConfNacosApi = (ConfNacosV1Api, ConfNacosV2Api);

--- a/spi/spi-conf/src/api/nacos.rs
+++ b/spi/spi-conf/src/api/nacos.rs
@@ -1,5 +1,4 @@
 mod v1;
-mod v2;
 pub use self::v1::*;
 mod v2;
 pub use self::v2::*;

--- a/spi/spi-conf/src/api/nacos/v1/auth.rs
+++ b/spi/spi-conf/src/api/nacos/v1/auth.rs
@@ -6,7 +6,7 @@ use tardis::web::{
 use crate::serv::*;
 use crate::{conf_config::ConfConfig, dto::conf_config_nacos_dto::*};
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct ConfNacosV1AuthApi;
 
 /// Interface Console config server API

--- a/spi/spi-conf/src/api/nacos/v1/config_service.rs
+++ b/spi/spi-conf/src/api/nacos/v1/config_service.rs
@@ -17,7 +17,7 @@ use crate::{conf_constants::error, serv::*};
 
 use super::tardis_err_to_poem_err;
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct ConfNacosV1CsApi;
 
 /// Interface Console config server API

--- a/spi/spi-conf/src/api/nacos/v1/namespace.rs
+++ b/spi/spi-conf/src/api/nacos/v1/namespace.rs
@@ -9,7 +9,7 @@ use crate::dto::{
 };
 use crate::serv::*;
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct ConfNacosV1NamespaceApi;
 
 /// Interface Console config server API

--- a/spi/spi-conf/src/api/nacos/v2/config_service.rs
+++ b/spi/spi-conf/src/api/nacos/v2/config_service.rs
@@ -1,0 +1,76 @@
+use tardis::web::{
+    poem::{self, web::Form},
+    poem_openapi::{self, param::Query, payload::Json},
+};
+
+use super::tardis_err_to_poem_err;
+use crate::dto::{conf_config_dto::*, conf_config_nacos_dto::*, conf_namespace_dto::*};
+use crate::serv::*;
+
+#[derive(Default, Clone, Copy, Debug)]
+pub struct ConfNacosV2CsApi;
+type NacosResult<T> = poem::Result<Json<NacosResponse<T>>>;
+/// Interface Console config server API
+#[poem_openapi::OpenApi(prefix_path = "/nacos/v2/cs", tag = "bios_basic::ApiTag::Interface")]
+impl ConfNacosV2CsApi {
+    #[oai(path = "/configs", method = "get")]
+    async fn get_config(
+        &self,
+        // mut descriptor: Query<ConfigDescriptor>,
+        tenant: Query<Option<NamespaceId>>,
+        #[oai(name = "namespaceId")] namespace_id: Query<Option<NamespaceId>>,
+        /// 配置分组名
+        group: Query<String>,
+        /// 配置名
+        #[oai(name = "dataId")]
+        data_id: Query<String>,
+        tag: Query<Option<String>>,
+        #[oai(name = "accessToken")] access_token: Query<String>,
+    ) -> NacosResult<String> {
+        let namespace_id = namespace_id.0.or(tenant.0).unwrap_or("public".into());
+        let tags = tag.0.map(|tag| tag.split(',').map(String::from).collect::<Vec<_>>()).unwrap_or_default();
+        let mut descriptor = ConfigDescriptor {
+            namespace_id,
+            group: group.0,
+            data_id: data_id.0,
+            tags,
+            ..Default::default()
+        };
+        let funs = crate::get_tardis_inst();
+        let ctx = jwt_validate(&access_token.0, &funs).await?;
+        let content = get_config(&mut descriptor, &funs, &ctx).await.map_err(tardis_err_to_poem_err)?;
+        Ok(Json(NacosResponse::ok(content)))
+    }
+    #[oai(path = "/configs", method = "post")]
+    async fn publish_config(&self, form: Form<PublishConfigFormV2>, #[oai(name = "accessToken")] access_token: Query<String>) -> NacosResult<bool> {
+        let funs = crate::get_tardis_inst();
+        let ctx = jwt_validate(&access_token.0, &funs).await?;
+        let mut publish_request = form.0.into();
+        let success = publish_config(&mut publish_request, &funs, &ctx).await?;
+        Ok(Json(NacosResponse::ok(success)))
+    }
+    #[oai(path = "/configs", method = "delete")]
+    async fn delete_config(
+        &self,
+        tenant: Query<Option<NamespaceId>>,
+        #[oai(name = "namespaceId")] namespace_id: Query<Option<NamespaceId>>,
+        /// 配置分组名
+        group: Query<String>,
+        /// 配置名
+        #[oai(name = "dataId")]
+        data_id: Query<String>,
+        #[oai(name = "accessToken")] access_token: Query<String>,
+    ) -> NacosResult<bool> {
+        let namespace_id = namespace_id.0.or(tenant.0).unwrap_or("public".into());
+        let mut descriptor = ConfigDescriptor {
+            namespace_id,
+            group: group.0,
+            data_id: data_id.0,
+            ..Default::default()
+        };
+        let funs = crate::get_tardis_inst();
+        let ctx = jwt_validate(&access_token.0, &funs).await?;
+        let success = delete_config(&mut descriptor, &funs, &ctx).await?;
+        Ok(Json(NacosResponse::ok(success)))
+    }
+}

--- a/spi/spi-conf/src/api/nacos/v2/mod.rs
+++ b/spi/spi-conf/src/api/nacos/v2/mod.rs
@@ -1,0 +1,15 @@
+// mod auth;
+mod config_service;
+mod namespace;
+use std::str::FromStr;
+
+pub use config_service::ConfNacosV2CsApi;
+pub use namespace::ConfNacosV2NamespaceApi;
+use tardis::{basic::error::TardisError, web::poem};
+pub type ConfNacosV2Api = (ConfNacosV2CsApi, ConfNacosV2NamespaceApi);
+pub use tardis::web::reqwest::StatusCode;
+
+fn tardis_err_to_poem_err(e: TardisError) -> poem::Error {
+    let status: StatusCode = StatusCode::from_str(&e.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    poem::Error::from_string(e.message, status)
+}

--- a/spi/spi-conf/src/api/nacos/v2/namespace.rs
+++ b/spi/spi-conf/src/api/nacos/v2/namespace.rs
@@ -1,0 +1,70 @@
+use tardis::web::{
+    poem::{self, web::Form},
+    poem_openapi::{self, param::Query, payload::Json},
+};
+
+use crate::dto::{
+    conf_config_nacos_dto::{NacosCreateNamespaceRequest, NacosDeleteNamespaceRequest, NacosEditNamespaceRequest, NacosResponse, NamespaceItemNacos},
+    conf_namespace_dto::*,
+};
+use crate::serv::*;
+
+#[derive(Default, Clone, Copy, Debug)]
+pub struct ConfNacosV2NamespaceApi;
+type NacosResult<T> = poem::Result<Json<NacosResponse<T>>>;
+
+/// Interface Console config server API
+#[poem_openapi::OpenApi(prefix_path = "/nacos/v2/console/namespace", tag = "bios_basic::ApiTag::Interface")]
+impl ConfNacosV2NamespaceApi {
+    #[oai(path = "/list", method = "get")]
+    /// because of nacos counterpart api's response is not paged, this api won't be paged either
+    async fn get_namespace_list(&self, #[oai(name = "accessToken")] access_token: Query<String>) -> NacosResult<Vec<NamespaceItemNacos>> {
+        let funs = crate::get_tardis_inst();
+        let ctx = jwt_validate(&access_token.0, &funs).await?;
+        let items = get_namespace_list(&funs, &ctx).await?.into_iter().map(NamespaceItemNacos::from).collect();
+        Ok(Json(NacosResponse::ok(items)))
+    }
+    #[oai(path = "/", method = "get")]
+    /// because of nacos counterpart api's response is not paged, this api won't be paged either
+    async fn get_namespace(
+        &self,
+        #[oai(name = "namespaceId")] namespace_id: Query<Option<NamespaceId>>,
+        #[oai(name = "accessToken")] access_token: Query<String>,
+    ) -> NacosResult<NamespaceItemNacos> {
+        let funs = crate::get_tardis_inst();
+        let ctx = jwt_validate(&access_token.0, &funs).await?;
+        let item = get_namespace(
+            &mut NamespaceDescriptor {
+                namespace_id: namespace_id.0.unwrap_or("public".into()),
+            },
+            &funs,
+            &ctx,
+        )
+        .await?;
+        Ok(Json(NacosResponse::ok(item.into())))
+    }
+    #[oai(path = "/", method = "post")]
+    async fn create_namespace(&self, form: Form<NacosCreateNamespaceRequest>, #[oai(name = "accessToken")] access_token: Query<String>) -> NacosResult<bool> {
+        let funs = crate::get_tardis_inst();
+        let ctx = jwt_validate(&access_token.0, &funs).await?;
+        let mut attribute = form.0.into();
+        create_namespace(&mut attribute, &funs, &ctx).await?;
+        Ok(Json(NacosResponse::ok(true)))
+    }
+    #[oai(path = "/", method = "put")]
+    async fn edit_namespace(&self, form: Form<NacosEditNamespaceRequest>, #[oai(name = "accessToken")] access_token: Query<String>) -> NacosResult<bool> {
+        let funs = crate::get_tardis_inst();
+        let ctx = jwt_validate(&access_token.0, &funs).await?;
+        let mut attribute = form.0.into();
+        edit_namespace(&mut attribute, &funs, &ctx).await?;
+        Ok(Json(NacosResponse::ok(true)))
+    }
+    #[oai(path = "/", method = "delete")]
+    async fn delete_namespace(&self, form: Form<NacosDeleteNamespaceRequest>, #[oai(name = "accessToken")] access_token: Query<String>) -> NacosResult<bool> {
+        let funs = crate::get_tardis_inst();
+        let ctx = jwt_validate(&access_token.0, &funs).await?;
+        let mut descriptor = NamespaceDescriptor { namespace_id: form.0.namespaceId };
+        delete_namespace(&mut descriptor, &funs, &ctx).await?;
+        Ok(Json(NacosResponse::ok(true)))
+    }
+}

--- a/spi/spi-conf/src/dto/conf_config_nacos_dto.rs
+++ b/spi/spi-conf/src/dto/conf_config_nacos_dto.rs
@@ -5,17 +5,98 @@ use serde::{Deserialize, Serialize};
 use tardis::web::poem_openapi;
 use tardis::web::poem_openapi::types::*;
 
-use super::conf_namespace_dto::NamespaceAttribute;
+use crate::utils::parse_tags;
+
+use super::conf_config_dto::{ConfigDescriptor, ConfigPublishRequest};
+use super::conf_namespace_dto::{NamespaceAttribute, NamespaceId, NamespaceItem};
 #[derive(Debug, Serialize, Deserialize, poem_openapi::Object)]
 pub struct NacosResponse<T: Type + ParseFromJSON + ToJSON> {
     code: u16,
-    message: Option<String>,
+    message: String,
     data: T,
 }
 
+macro_rules! define_api_code {
+    (
+        $(
+            $(#[$attr:meta])*
+            $name:ident: $code:literal, $message:literal;
+        )*
+
+    ) => {
+        $(
+            $(#[$attr])*
+            pub fn $name(data: T) -> Self {
+                Self { code: $code, message: $message.to_string(), data }
+            }
+        )*
+    };
+}
+
 impl<T: Type + ParseFromJSON + ToJSON> NacosResponse<T> {
-    pub const fn ok(data: T) -> Self {
-        Self { code: 200, message: None, data }
+    define_api_code! {
+        /// 成功
+        ok: 0, "success";
+        /// 参数缺失
+        parameter_missing: 10000, "parameter missing";
+        /// 访问拒绝
+        access_denied: 10001, "access denied";
+        /// 数据访问错误
+        data_access_error: 10002, "data access error";
+        /// tenant参数错误
+        tenant_parameter_error: 20001, "'tenant' parameter error";
+        /// 参数验证错误
+        parameter_validate_error: 20002, "parameter validate error";
+        /// 请求的MediaType错误
+        media_type_error: 20003, "MediaType Error";
+        /// 资源未找到
+        resource_not_found: 20004, "resource not found";
+        /// 资源访问冲突
+        resource_conflict: 20005, "resource conflict";
+        /// 监听配置为空
+        config_listener_is_null: 20006, "config listener is null";
+        /// 监听配置错误
+        config_listener_error: 20007, "config listener error";
+        /// 无效的dataId（鉴权失败）
+        invalid_dataid: 20008, "invalid dataId";
+        /// 请求参数不匹配
+        parameter_mismatch: 20009, "parameter mismatch";
+        /// serviceName服务名错误
+        service_name_error: 21000, "service name error";
+        /// weight权重参数错误
+        weight_error: 21001, "weight error";
+        /// 实例metadata元数据错误
+        instance_metadata_error: 21002, "instance metadata error";
+        /// instance实例不存在
+        instance_not_found: 21003, "instance not found";
+        /// instance实例信息错误
+        instance_error: 21004, "instance error";
+        /// 服务metadata元数据错误
+        service_metadata_error: 21005, "service metadata error";
+        /// 访问策略selector错误
+        selector_error: 21006, "selector error";
+        /// 服务已存在
+        service_already_exist: 21007, "service already exist";
+        /// 服务不存在
+        service_not_exist: 21008, "service not exist";
+        /// 存在服务实例，服务删除失败
+        service_delete_failure: 21009, "service delete failure";
+        /// healthy参数缺失
+        healthy_param_miss: 21010, "healthy param miss";
+        /// 健康检查仍在运行
+        health_check_still_running: 21011, "health check still running";
+        /// 命名空间namespace不合法
+        illegal_namespace: 22000, "illegal namespace";
+        /// 命名空间不存在
+        namespace_not_exist: 22001, "namespace not exist";
+        /// 命名空间已存在
+        namespace_already_exist: 22002, "namespace already exist";
+        /// 状态state不合法
+        illegal_state: 23000, "illegal state";
+        /// 节点信息错误
+        node_info_error: 23001, "node info error";
+        /// 节点离线操作出错
+        node_down_failure: 23002, "node down failure";
     }
 }
 
@@ -44,6 +125,7 @@ pub struct LoginRequest {
 
 #[derive(poem_openapi::Object, Serialize, Deserialize, Debug, Default)]
 #[serde(rename = "camelCase")]
+#[oai(rename_all = "camelCase")]
 pub struct LoginResponse {
     #[oai(rename = "accessToken")]
     pub access_token: String,
@@ -58,6 +140,61 @@ pub struct PublishConfigForm {
     pub content: String,
 }
 
+#[derive(poem_openapi::Object, Serialize, Deserialize, Debug, Default)]
+#[allow(non_snake_case)]
+pub struct PublishConfigFormV2 {
+    //否 命名空间，默认为public与 ''相同
+    pub namespaceId: Option<String>,
+    #[oai(validator(min_length = 1, max_length = 256))]
+    //是 配置组名
+    pub group: String,
+    #[oai(validator(min_length = 1, max_length = 256))]
+    //是 配置名
+    pub dataId: String,
+    //是 配置内容
+    pub content: String,
+    //否 标签
+    pub tag: Option<String>,
+    //否 应用名
+    pub appName: Option<String>,
+    //否 源用户
+    pub srcUser: Option<String>,
+    //否 配置标签列表，可多个，逗号分隔
+    pub configTags: Option<String>,
+    //否 配置描述
+    pub desc: Option<String>,
+    //否 -
+    pub r#use: Option<String>,
+    //否 -
+    pub effect: Option<String>,
+    //否 配置类型
+    pub r#type: Option<String>,
+    //否 -
+    pub schema: Option<String>,
+}
+
+impl From<PublishConfigFormV2> for ConfigPublishRequest {
+    fn from(val: PublishConfigFormV2) -> Self {
+        let config_tags = val.configTags.as_deref().map(parse_tags).unwrap_or_default();
+        ConfigPublishRequest {
+            content: val.content,
+            descriptor: ConfigDescriptor {
+                namespace_id: val.namespaceId.unwrap_or("public".into()),
+                group: val.group,
+                data_id: val.dataId,
+                tags: val.tag.into_iter().collect(),
+                tp: val.r#type,
+            },
+            app_name: val.appName,
+            src_user: val.srcUser,
+            config_tags,
+            desc: val.desc,
+            r#use: val.r#use,
+            effect: val.effect,
+            schema: val.schema,
+        }
+    }
+}
 #[derive(poem_openapi::Object, Serialize, Deserialize, Debug, Default)]
 #[allow(non_snake_case)]
 pub struct NacosCreateNamespaceRequest {
@@ -96,6 +233,33 @@ impl From<NacosEditNamespaceRequest> for NamespaceAttribute {
             namespace: value.namespace,
             namespace_show_name: value.namespaceShowName,
             namespace_desc: value.namespaceDesc,
+        }
+    }
+}
+
+#[derive(poem_openapi::Object, Serialize, Deserialize, Debug, Default)]
+#[allow(non_snake_case)]
+pub struct NamespaceItemNacos {
+    pub namespace: NamespaceId,
+    pub namespaceShowName: String,
+    pub namespaceDesc: Option<String>,
+    pub r#type: u32,
+    /// quota / 容量,
+    /// refer to design of nacos,
+    /// see: https://github.com/alibaba/nacos/issues/4558
+    pub quota: u32,
+    pub configCount: u32,
+}
+
+impl From<NamespaceItem> for NamespaceItemNacos {
+    fn from(value: NamespaceItem) -> Self {
+        Self {
+            namespace: value.namespace,
+            namespaceShowName: value.namespace_show_name,
+            namespaceDesc: value.namespace_desc,
+            r#type: value.tp,
+            quota: value.quota,
+            configCount: value.config_count,
         }
     }
 }

--- a/spi/spi-conf/src/dto/conf_namespace_dto.rs
+++ b/spi/spi-conf/src/dto/conf_namespace_dto.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tardis::web::poem_openapi;
+use tardis::web::poem_openapi::{self};
 pub type NamespaceId = String;
 
 #[derive(poem_openapi::Object, Serialize, Deserialize, Debug, Default)]

--- a/spi/spi-conf/src/utils.rs
+++ b/spi/spi-conf/src/utils.rs
@@ -19,3 +19,19 @@ pub(crate) fn random_ak() -> String {
 pub(crate) fn random_sk() -> String {
     crate::utils::random_string(12, CHARSET_AK)
 }
+
+pub(crate) fn parse_tags(tags: &str) -> Vec<String> {
+    let mut v = tags
+        .split(',')
+        .filter_map(|t| {
+            let t = t.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.to_string())
+            }
+        })
+        .collect::<Vec<_>>();
+    v.dedup();
+    v
+}

--- a/spi/spi-conf/tests/config/conf-nacos.toml
+++ b/spi/spi-conf/tests/config/conf-nacos.toml
@@ -66,4 +66,7 @@ FZygs8miAhWPzqnpmgTj1cPiU1M=
 [fw.web_server.modules.spi-conf]
 title = "配置服务"
 doc_urls = [["test env", "http://localhost:8080/"]]
+uniform_error = true
+[fw.web_server.modules.spi-conf-nacos]
+title = "配置nacos服务"
 uniform_error = false

--- a/spi/spi-conf/tests/spi_conf_api_test.rs
+++ b/spi/spi-conf/tests/spi_conf_api_test.rs
@@ -3,7 +3,7 @@ use std::env;
 use bios_basic::{
     rbum::serv::rbum_kind_serv::RbumKindServ,
     spi::{dto::spi_bs_dto::SpiBsAddReq, spi_constants},
-    test::{init_rbum_test_container, test_http_client::TestHttpClient},
+    test::test_http_client::TestHttpClient,
 };
 use bios_spi_conf::{
     conf_constants::DOMAIN_CODE,
@@ -28,8 +28,7 @@ use spi_conf_test_common::*;
 async fn spi_conf_namespace_test() -> TardisResult<()> {
     std::env::set_var("RUST_LOG", "info,sqlx=off,sea_orm=debug,spi_conf_namespace_test=DEBUG,bios_spi_conf=TRACE");
     let docker = testcontainers::clients::Cli::default();
-    let container_hold = init_rbum_test_container::init(&docker, None).await?;
-    init_tardis().await?;
+    let container_hold = init_tardis(&docker).await?;
     let _web_server_hanlde = start_web_server();
     let tardis_ctx = TardisContext::default();
     let mut client = TestHttpClient::new("https://localhost:8080/spi-conf".to_string());

--- a/spi/spi-conf/tests/spi_conf_listener_test.rs
+++ b/spi/spi-conf/tests/spi_conf_listener_test.rs
@@ -6,7 +6,7 @@ use std::{
 use bios_basic::{
     rbum::serv::rbum_kind_serv::RbumKindServ,
     spi::{dto::spi_bs_dto::SpiBsAddReq, spi_constants},
-    test::{init_rbum_test_container, test_http_client::TestHttpClient},
+    test::test_http_client::TestHttpClient,
 };
 use bios_spi_conf::{conf_constants::DOMAIN_CODE, dto::conf_config_dto::ConfigDescriptor};
 use tardis::{
@@ -25,8 +25,7 @@ use spi_conf_test_common::*;
 async fn spi_conf_namespace_test() -> TardisResult<()> {
     std::env::set_var("RUST_LOG", "error,spi_conf_listener_test=debug,sqlx=off,sea_orm=off,bios_spi_conf=DEBUG");
     let docker = testcontainers::clients::Cli::default();
-    let container_hold = init_rbum_test_container::init(&docker, None).await?;
-    init_tardis().await?;
+    let container_hold = init_tardis(&docker).await?;
     let _web_server_hanlde = start_web_server();
     let tardis_ctx = TardisContext::default();
     let mut client = TestHttpClient::new("https://localhost:8080/spi-conf".to_string());

--- a/spi/spi-conf/tests/spi_conf_nacos_compatible_test.rs
+++ b/spi/spi-conf/tests/spi_conf_nacos_compatible_test.rs
@@ -9,6 +9,7 @@ use bios_spi_conf::{
     conf_constants::DOMAIN_CODE,
     dto::conf_auth_dto::{RegisterRequest, RegisterResponse},
 };
+use reqwest::{Request, Method, RequestBuilder};
 use tardis::{
     basic::{dto::TardisContext, field::TrimString, result::TardisResult},
     log, testcontainers, tokio,
@@ -24,8 +25,7 @@ async fn spi_conf_namespace_test() -> TardisResult<()> {
     std::env::set_var("RUST_LOG", "info,tardis=debug,spi_conf_listener_test=debug,sqlx=off,sea_orm=off,bios_spi_conf=DEBUG");
     std::env::set_var("PROFILE", "nacos");
     let docker = testcontainers::clients::Cli::default();
-    let container_hold = init_rbum_test_container::init(&docker, None).await?;
-    init_tardis().await?;
+    let container_hold = init_tardis(&docker).await?;
     let _web_server_hanlde = start_web_server();
     let tardis_ctx = TardisContext::default();
     let mut client = TestHttpClient::new("https://localhost:8080/spi-conf".to_string());
@@ -79,8 +79,8 @@ async fn test_tardis_compatibility(_test_client: &TestHttpClient) -> TardisResul
     let mut headers = reqwest::header::HeaderMap::new();
     headers.append(TardisFuns::fw_config().web_server.context_conf.context_header_name.as_str(), ctx_base64.parse().unwrap());
     let client = reqwest::ClientBuilder::default().danger_accept_invalid_certs(true).default_headers(headers).build().unwrap();
-    let mut nacos_client = NacosClient::new_with_client("https://localhost:8080/spi-conf/nacos", client);
-    let resp = nacos_client.post("https://localhost:8080/spi-conf/ci/auth/register").json(&RegisterRequest::default()).send().await?;
+    let mut nacos_client = NacosClient::new_with_client("https://localhost:8080/spi-conf-nacos/nacos", client);
+    let resp = nacos_client.reqwest_client.post("https://localhost:8080/spi-conf/ci/auth/register").json(&RegisterRequest::default()).send().await?;
     let resp = resp.json::<TardisResp<RegisterResponse>>().await?;
     let auth = resp.data.expect("error in register");
 
@@ -126,6 +126,7 @@ async fn test_tardis_compatibility(_test_client: &TestHttpClient) -> TardisResul
     let username = "nacosmocker";
     let password = "nacosmocker";
     let resp = nacos_client
+        .reqwest_client
         .post("https://localhost:8080/spi-conf/ci/auth/register")
         .json(&RegisterRequest {
             username: Some(username.into()),
@@ -137,21 +138,23 @@ async fn test_tardis_compatibility(_test_client: &TestHttpClient) -> TardisResul
     let auth = resp.data.expect("error in register");
     assert_eq!(username, auth.username);
     assert_eq!(password, auth.password);
-    let login_url = "https://localhost:8080/spi-conf/nacos/v1/auth/login";
+    let login_url = "https://localhost:8080/spi-conf-nacos/nacos/v1/auth/login";
     let mut form = HashMap::new();
     form.insert("password", username);
     form.insert("username", password);
-    let resp = nacos_client.post(login_url).form(&form).send().await?;
+    let resp = nacos_client.reqwest_client.post(login_url).form(&form).send().await?;
     log::info!("response: {resp:#?}");
 
     let value = resp.json::<tardis::serde_json::Value>().await?;
     let token = value.get("accessToken").expect("missing accessToken").as_str().expect("access_token should be string");
-    let namespace_url = "https://localhost:8080/spi-conf/nacos/v1/console/namespaces";
+    let namespace_url = "https://localhost:8080/spi-conf-nacos/nacos/v1/console/namespaces";
     let mut form = HashMap::new();
     form.insert("customNamespaceId", "test-namespace-1");
     form.insert("namespaceName", "测试命名空间1");
     // publish
-    let resp = nacos_client.post(namespace_url).query(&[("accessToken", token)]).form(&form).send().await?;
+    let reqwest_client = nacos_client.reqwest_client.clone();
+    let req = reqwest_client.post(namespace_url).form(&form).build()?;
+    let resp = nacos_client.reqwest_execute(req).await?;
     log::info!("response: {resp:#?}");
     let success = resp.json::<bool>().await?;
     assert!(success);
@@ -159,7 +162,7 @@ async fn test_tardis_compatibility(_test_client: &TestHttpClient) -> TardisResul
     let mut form = HashMap::new();
     form.insert("namespace", "test-namespace-1");
     form.insert("namespaceShowName", "测试命名空间1-修改");
-    let resp = nacos_client.put(namespace_url).query(&[("accessToken", token)]).form(&form).send().await?;
+    let resp = nacos_client.reqwest_client.put(namespace_url).query(&[("accessToken", token)]).form(&form).send().await?;
     // let info = resp.text().await?;
     // log::info!("response: {info}");
     let success = resp.json::<bool>().await?;
@@ -168,7 +171,7 @@ async fn test_tardis_compatibility(_test_client: &TestHttpClient) -> TardisResul
     // delete
     let mut form = HashMap::new();
     form.insert("namespaceId", "test-namespace-1");
-    let resp = nacos_client.delete(namespace_url).query(&[("accessToken", token)]).form(&form).send().await?;
+    let resp = nacos_client.reqwest_client.delete(namespace_url).query(&[("accessToken", token)]).form(&form).send().await?;
     // let info = resp.text().await?;
     // log::info!("response: {info}");
     let success = resp.json::<bool>().await?;

--- a/spi/spi-conf/tests/spi_conf_nacos_compatible_test.rs
+++ b/spi/spi-conf/tests/spi_conf_nacos_compatible_test.rs
@@ -3,13 +3,12 @@ use std::{collections::HashMap, env};
 use bios_basic::{
     rbum::serv::rbum_kind_serv::RbumKindServ,
     spi::{dto::spi_bs_dto::SpiBsAddReq, spi_constants},
-    test::{init_rbum_test_container, test_http_client::TestHttpClient},
+    test::test_http_client::TestHttpClient,
 };
 use bios_spi_conf::{
     conf_constants::DOMAIN_CODE,
     dto::conf_auth_dto::{RegisterRequest, RegisterResponse},
 };
-use reqwest::{Request, Method, RequestBuilder};
 use tardis::{
     basic::{dto::TardisContext, field::TrimString, result::TardisResult},
     log, testcontainers, tokio,
@@ -152,9 +151,7 @@ async fn test_tardis_compatibility(_test_client: &TestHttpClient) -> TardisResul
     form.insert("customNamespaceId", "test-namespace-1");
     form.insert("namespaceName", "测试命名空间1");
     // publish
-    let reqwest_client = nacos_client.reqwest_client.clone();
-    let req = reqwest_client.post(namespace_url).form(&form).build()?;
-    let resp = nacos_client.reqwest_execute(req).await?;
+    let resp = nacos_client.reqwest_execute(|c| c.post(namespace_url).form(&form)).await?;
     log::info!("response: {resp:#?}");
     let success = resp.json::<bool>().await?;
     assert!(success);

--- a/spi/spi-conf/tests/spi_conf_test_common.rs
+++ b/spi/spi-conf/tests/spi_conf_test_common.rs
@@ -3,21 +3,38 @@ use bios_basic::{
     test::test_http_client::TestHttpClient,
 };
 use bios_spi_conf::{conf_constants::DOMAIN_CODE, conf_initializer};
+use tardis::testcontainers::images::{generic::GenericImage, redis::Redis};
 use tardis::{
     basic::{dto::TardisContext, result::TardisResult},
+    test::test_container::TardisTestContainer,
+    testcontainers::{clients::Cli, Container},
     tokio::{self, task::JoinHandle},
     TardisFuns,
 };
-
+pub struct Holder<'d> {
+    pg: Container<'d, GenericImage>,
+    redis: Container<'d, Redis>,
+}
 #[allow(dead_code)]
-pub async fn init_tardis() -> TardisResult<()> {
+pub async fn init_tardis(docker: &Cli) -> TardisResult<Holder> {
+    let reldb_container = TardisTestContainer::postgres_custom(None, docker);
+    let port = reldb_container.get_host_port_ipv4(5432);
+    let url = format!("postgres://postgres:123456@localhost:{port}/test");
+    std::env::set_var("TARDIS_FW.DB.URL", url);
+    let redis_container = TardisTestContainer::redis_custom(docker);
+    let port = redis_container.get_host_port_ipv4(6379);
+    let url = format!("redis://127.0.0.1:{port}/0");
+    std::env::set_var("TARDIS_FW.CACHE.URL", url);
+    let holder = Holder {
+        pg: reldb_container,
+        redis: redis_container,
+    };
     TardisFuns::init(Some("tests/config")).await?;
     bios_basic::rbum::rbum_initializer::init(DOMAIN_CODE, RbumConfig::default()).await?;
-
     let web_server = TardisFuns::web_server();
     rbum_initializer::init("bios-spi", RbumConfig::default()).await?;
     conf_initializer::init(web_server).await?;
-    Ok(())
+    Ok(holder)
 }
 
 #[allow(dead_code)]

--- a/spi/spi-conf/tests/spi_conf_test_common.rs
+++ b/spi/spi-conf/tests/spi_conf_test_common.rs
@@ -12,8 +12,8 @@ use tardis::{
     TardisFuns,
 };
 pub struct Holder<'d> {
-    pg: Container<'d, GenericImage>,
-    redis: Container<'d, Redis>,
+    pub pg: Container<'d, GenericImage>,
+    pub redis: Container<'d, Redis>,
 }
 #[allow(dead_code)]
 pub async fn init_tardis(docker: &Cli) -> TardisResult<Holder> {

--- a/spi/spi-graph/src/api/ci/graph_ci_basic_api.rs
+++ b/spi/spi-graph/src/api/ci/graph_ci_basic_api.rs
@@ -7,7 +7,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisResp, Void};
 
 use crate::dto::graph_dto::{GraphNodeVersionResp, GraphRelAddReq, GraphRelDetailResp, GraphRelUpgardeVersionReq};
 use crate::serv::graph_basic_serv;
-
+#[derive(Clone)]
 pub struct GraphCiRelApi;
 
 /// Interface Console Graph API

--- a/spi/spi-graph/src/graph_initializer.rs
+++ b/spi/spi-graph/src/graph_initializer.rs
@@ -23,7 +23,7 @@ async fn init_db(funs: &TardisFunsInst, ctx: &TardisContext) -> TardisResult<()>
 }
 
 async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
-    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, graph_ci_basic_api::GraphCiRelApi), None).await;
+    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, graph_ci_basic_api::GraphCiRelApi)).await;
     Ok(())
 }
 

--- a/spi/spi-kv/src/api/ci/kv_ci_item_api.rs
+++ b/spi/spi-kv/src/api/ci/kv_ci_item_api.rs
@@ -10,6 +10,7 @@ use crate::dto::kv_item_dto::{
 };
 use crate::serv::kv_item_serv;
 
+#[derive(Clone)]
 pub struct KvCiItemApi;
 
 /// Interface Console KV API

--- a/spi/spi-kv/src/kv_initializer.rs
+++ b/spi/spi-kv/src/kv_initializer.rs
@@ -23,7 +23,7 @@ async fn init_db(funs: &TardisFunsInst, ctx: &TardisContext) -> TardisResult<()>
 }
 
 async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
-    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, kv_ci_item_api::KvCiItemApi), None).await;
+    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, kv_ci_item_api::KvCiItemApi)).await;
     Ok(())
 }
 

--- a/spi/spi-log/src/api/ci/log_ci_item_api.rs
+++ b/spi/spi-log/src/api/ci/log_ci_item_api.rs
@@ -8,7 +8,6 @@ use crate::dto::log_item_dto::{LogItemAddReq, LogItemFindReq, LogItemFindResp};
 use crate::serv::log_item_serv;
 
 #[derive(Clone)]
-
 pub struct LogCiItemApi;
 
 /// Interface Console Log API

--- a/spi/spi-log/src/api/ci/log_ci_item_api.rs
+++ b/spi/spi-log/src/api/ci/log_ci_item_api.rs
@@ -7,6 +7,8 @@ use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp, Void};
 use crate::dto::log_item_dto::{LogItemAddReq, LogItemFindReq, LogItemFindResp};
 use crate::serv::log_item_serv;
 
+#[derive(Clone)]
+
 pub struct LogCiItemApi;
 
 /// Interface Console Log API

--- a/spi/spi-log/src/log_initializer.rs
+++ b/spi/spi-log/src/log_initializer.rs
@@ -23,7 +23,7 @@ async fn init_db(funs: &TardisFunsInst, ctx: &TardisContext) -> TardisResult<()>
 }
 
 async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
-    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, log_ci_item_api::LogCiItemApi), None).await;
+    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, log_ci_item_api::LogCiItemApi)).await;
     Ok(())
 }
 

--- a/spi/spi-object/src/api/ci/object_ci_obj_api.rs
+++ b/spi/spi-object/src/api/ci/object_ci_obj_api.rs
@@ -6,7 +6,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisResp};
 
 use crate::dto::object_dto::ObjectObjPresignKind;
 use crate::serv::object_obj_serv;
-
+#[derive(Clone)]
 pub struct ObjectCiObjApi;
 
 /// Interface Console Object API

--- a/spi/spi-object/src/object_initializer.rs
+++ b/spi/spi-object/src/object_initializer.rs
@@ -28,7 +28,7 @@ async fn init_db(funs: &TardisFunsInst, ctx: &TardisContext) -> TardisResult<()>
 }
 
 async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
-    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, object_ci_obj_api::ObjectCiObjApi), None).await;
+    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, object_ci_obj_api::ObjectCiObjApi)).await;
     Ok(())
 }
 

--- a/spi/spi-plugin/src/api/ci/plugin_ci_api_api.rs
+++ b/spi/spi-plugin/src/api/ci/plugin_ci_api_api.rs
@@ -11,6 +11,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp, Void};
 
 use crate::dto::plugin_api_dto::{PluginApiAddOrModifyReq, PluginApiFilterReq, PluginApiSummaryResp};
 use crate::serv::plugin_api_serv::PluginApiServ;
+#[derive(Clone)]
 
 pub struct PluginApiApi;
 

--- a/spi/spi-plugin/src/api/ci/plugin_ci_bs_api.rs
+++ b/spi/spi-plugin/src/api/ci/plugin_ci_bs_api.rs
@@ -14,6 +14,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp, Void};
 
 use crate::dto::plugin_bs_dto::{PluginBsAddReq, PluginBsInfoResp};
 use crate::serv::plugin_bs_serv::PluginBsServ;
+#[derive(Clone)]
 
 pub struct PluginCiBsApi;
 

--- a/spi/spi-plugin/src/api/ci/plugin_ci_exec_api.rs
+++ b/spi/spi-plugin/src/api/ci/plugin_ci_exec_api.rs
@@ -8,6 +8,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisResp};
 
 use crate::dto::plugin_exec_dto::{PluginExecReq, PluginExecResp};
 use crate::serv::plugin_exec_serv::PluginExecServ;
+#[derive(Clone)]
 
 pub struct PluginExecApi;
 

--- a/spi/spi-plugin/src/api/ci/plugin_ci_kind_api.rs
+++ b/spi/spi-plugin/src/api/ci/plugin_ci_kind_api.rs
@@ -15,6 +15,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp, Void};
 use crate::dto::plugin_kind_dto::{PluginKindAddAggReq, PluginKindAggResp};
 use crate::plugin_constants::KIND_MODULE_CODE;
 use crate::serv::plugin_kind_serv::PluginKindServ;
+#[derive(Clone)]
 
 pub struct PluginKindApi;
 

--- a/spi/spi-plugin/src/plugin_initializer.rs
+++ b/spi/spi-plugin/src/plugin_initializer.rs
@@ -37,7 +37,6 @@ async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
                 plugin_ci_exec_api::PluginExecApi,
                 plugin_ci_kind_api::PluginKindApi,
             ),
-            None,
         )
         .await;
     Ok(())

--- a/spi/spi-reldb/src/api/ci/reldb_ci_exec_api.rs
+++ b/spi/spi-reldb/src/api/ci/reldb_ci_exec_api.rs
@@ -9,6 +9,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisResp, Void};
 use crate::dto::reldb_exec_dto::{ReldbDdlReq, ReldbDmlReq, ReldbDmlResp, ReldbDqlReq, ReldbTxResp};
 use crate::serv::reldb_exec_serv;
 
+#[derive(Clone)]
 pub struct ReldbCiExecApi;
 
 /// Interface Console RelDB Execute API

--- a/spi/spi-reldb/src/reldb_initializer.rs
+++ b/spi/spi-reldb/src/reldb_initializer.rs
@@ -40,7 +40,7 @@ async fn init_db(funs: &TardisFunsInst, ctx: &TardisContext) -> TardisResult<()>
 }
 
 async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
-    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, reldb_ci_exec_api::ReldbCiExecApi), None).await;
+    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, reldb_ci_exec_api::ReldbCiExecApi)).await;
     Ok(())
 }
 

--- a/spi/spi-search/src/api/ci/search_ci_item_api.rs
+++ b/spi/spi-search/src/api/ci/search_ci_item_api.rs
@@ -8,6 +8,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp, Void};
 use crate::dto::search_item_dto::{SearchItemAddReq, SearchItemModifyReq, SearchItemSearchReq, SearchItemSearchResp};
 use crate::serv::search_item_serv;
 
+#[derive(Clone)]
 pub struct SearchCiItemApi;
 
 /// Interface Console Search API

--- a/spi/spi-search/src/search_initializer.rs
+++ b/spi/spi-search/src/search_initializer.rs
@@ -23,7 +23,7 @@ async fn init_db(funs: &TardisFunsInst, ctx: &TardisContext) -> TardisResult<()>
 }
 
 async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
-    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, search_ci_item_api::SearchCiItemApi), None).await;
+    web_server.add_module(DOMAIN_CODE, (spi_ci_bs_api::SpiCiBsApi, search_ci_item_api::SearchCiItemApi)).await;
     Ok(())
 }
 

--- a/spi/spi-stats/src/api/ci/stats_ci_conf_api.rs
+++ b/spi/spi-stats/src/api/ci/stats_ci_conf_api.rs
@@ -11,6 +11,7 @@ use crate::dto::stats_conf_dto::{
 };
 use crate::serv::stats_conf_serv;
 
+#[derive(Clone)]
 pub struct StatsCiConfApi;
 
 /// Interface Console Statistics Configuration API

--- a/spi/spi-stats/src/api/ci/stats_ci_metric_api.rs
+++ b/spi/spi-stats/src/api/ci/stats_ci_metric_api.rs
@@ -7,6 +7,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisResp};
 use crate::dto::stats_query_dto::{StatsQueryMetricsReq, StatsQueryMetricsResp};
 use crate::serv::stats_metric_serv;
 
+#[derive(Clone)]
 pub struct StatsCiMetricApi;
 
 /// Interface Console Statistics Metric API

--- a/spi/spi-stats/src/api/ci/stats_ci_record_api.rs
+++ b/spi/spi-stats/src/api/ci/stats_ci_record_api.rs
@@ -10,6 +10,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp, Void};
 use crate::dto::stats_record_dto::{StatsDimRecordAddReq, StatsDimRecordDeleteReq, StatsFactRecordLoadReq, StatsFactRecordsLoadReq};
 use crate::serv::stats_record_serv;
 
+#[derive(Clone)]
 pub struct StatsCiRecordApi;
 
 /// Interface Console Statistics Record API

--- a/spi/spi-stats/src/stats_initializer.rs
+++ b/spi/spi-stats/src/stats_initializer.rs
@@ -34,7 +34,6 @@ async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
                 stats_ci_record_api::StatsCiRecordApi,
                 stats_ci_metric_api::StatsCiMetricApi,
             ),
-            None,
         )
         .await;
     Ok(())

--- a/support/auth/src/api/auth_crypto_api.rs
+++ b/support/auth/src/api/auth_crypto_api.rs
@@ -8,6 +8,7 @@ use crate::dto::auth_crypto_dto::{AuthEncryptReq, AuthEncryptResp};
 use crate::serv::auth_crypto_serv;
 use crate::serv::clients::spi_log_client::{LogParamContent, SpiLogClient};
 
+#[derive(Clone)]
 pub struct CryptoApi;
 
 /// Crypto API

--- a/support/auth/src/api/auth_kernel_api.rs
+++ b/support/auth/src/api/auth_kernel_api.rs
@@ -10,6 +10,7 @@ use crate::dto::auth_kernel_dto::{AuthReq, AuthResp, MixAuthResp};
 use crate::serv::clients::spi_log_client::{LogParamContent, SpiLogClient};
 use crate::serv::{auth_kernel_serv, auth_res_serv};
 
+#[derive(Clone)]
 pub struct AuthApi;
 
 /// Auth API

--- a/support/auth/src/api/auth_mgr_api.rs
+++ b/support/auth/src/api/auth_mgr_api.rs
@@ -1,5 +1,6 @@
 use tardis::web::poem_openapi;
 
+#[derive(Clone)]
 pub struct MgrApi;
 
 /// Management API

--- a/support/auth/src/auth_initializer.rs
+++ b/support/auth/src/auth_initializer.rs
@@ -102,6 +102,6 @@ pub async fn init_data() -> TardisResult<()> {
 }
 
 pub async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
-    web_server.add_module(DOMAIN_CODE, (auth_mgr_api::MgrApi, auth_crypto_api::CryptoApi, auth_kernel_api::AuthApi), None).await;
+    web_server.add_module(DOMAIN_CODE, (auth_mgr_api::MgrApi, auth_crypto_api::CryptoApi, auth_kernel_api::AuthApi)).await;
     Ok(())
 }

--- a/support/auth/src/serv/auth_kernel_serv.rs
+++ b/support/auth/src/serv/auth_kernel_serv.rs
@@ -201,7 +201,7 @@ async fn ident(req: &AuthReq, config: &AuthConfig, cache_client: &TardisCacheCli
             }
             cache_own_paths = format!("{cache_tenant_id}/{app_id}")
         }
-        if own_paths.contains((&cache_own_paths)) {
+        if own_paths.contains(&cache_own_paths) {
             let own_paths_split = own_paths.split('/').collect::<Vec<_>>();
             let tenant_id = if own_paths.is_empty() { None } else { Some(own_paths_split[0].to_string()) };
             let app_id = if own_paths_split.len() > 1 { Some(own_paths_split[1].to_string()) } else { None };
@@ -291,7 +291,7 @@ async fn check_ak_signature(ak: &str, cache_sk: &str, signature: &str, req_date:
     let sorted_req_query = auth_common_helper::sort_hashmap_query(req.query.clone());
     let calc_signature = TardisFuns::crypto
         .base64
-        .encode(&TardisFuns::crypto.digest.hmac_sha256(&format!("{}\n{}\n{}\n{}", req.method, req_date, req.path, sorted_req_query).to_lowercase(), &cache_sk)?);
+        .encode(&TardisFuns::crypto.digest.hmac_sha256(&format!("{}\n{}\n{}\n{}", req.method, req_date, req.path, sorted_req_query).to_lowercase(), cache_sk)?);
     if calc_signature != signature {
         return Err(TardisError::unauthorized(&format!("Ak [{ak}] authentication failed"), "401-auth-req-authenticate-fail"));
     }
@@ -313,7 +313,7 @@ async fn check_webhook_ak_signature(
     let sorted_req_query = auth_common_helper::sort_hashmap_query(query);
     let calc_signature = TardisFuns::crypto.base64.encode(&TardisFuns::crypto.digest.hmac_sha256(
         &format!("{}\n{}\n{}\n{}\n{}\n{}", onwer, onwer_path, req.method, req_date, req.path, sorted_req_query).to_lowercase(),
-        &cache_sk,
+        cache_sk,
     )?);
     if calc_signature != signature {
         return Err(TardisError::unauthorized(&format!("Ak [{ak}] authentication failed"), "401-auth-req-authenticate-fail"));

--- a/support/auth/tests/test_auth_init.rs
+++ b/support/auth/tests/test_auth_init.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use bios_auth::{auth_config::AuthConfig, auth_constants::DOMAIN_CODE, auth_initializer, serv::auth_res_serv};
-use tardis::{basic::result::TardisResult, chrono::Utc, tokio::time::sleep, web::poem_openapi::types::Type, TardisFuns};
+use tardis::{basic::result::TardisResult, chrono::Utc, tokio::time::sleep, TardisFuns};
 
 pub async fn test_init() -> TardisResult<()> {
     let config = TardisFuns::cs_config::<AuthConfig>(DOMAIN_CODE);

--- a/support/iam/src/basic/middleware/encrypt_mw.rs
+++ b/support/iam/src/basic/middleware/encrypt_mw.rs
@@ -14,7 +14,7 @@ use tardis::{
 };
 
 use crate::{iam_config::IamConfig, iam_constants};
-
+#[derive(Clone, Debug)]
 pub struct EncryptMW;
 
 impl EncryptMW {

--- a/support/iam/src/console_app/api/iam_ca_account_api.rs
+++ b/support/iam/src/console_app/api/iam_ca_account_api.rs
@@ -14,6 +14,7 @@ use crate::basic::serv::iam_app_serv::IamAppServ;
 use crate::iam_constants;
 use crate::iam_enumeration::IamRelKind;
 
+#[derive(Clone, Default)]
 pub struct IamCaAccountApi;
 
 /// App Console Account API

--- a/support/iam/src/console_app/api/iam_ca_app_api.rs
+++ b/support/iam/src/console_app/api/iam_ca_app_api.rs
@@ -11,6 +11,7 @@ use crate::basic::dto::iam_filer_dto::IamAppFilterReq;
 use crate::basic::serv::iam_app_serv::IamAppServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCaAppApi;
 
 /// App Console App API

--- a/support/iam/src/console_app/api/iam_ca_cert_manage_api.rs
+++ b/support/iam/src/console_app/api/iam_ca_cert_manage_api.rs
@@ -9,6 +9,7 @@ use bios_basic::rbum::dto::rbum_rel_dto::RbumRelBoneResp;
 use crate::basic::serv::iam_cert_serv::IamCertServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCaCertManageApi;
 
 /// Tenant Console Cert manage API

--- a/support/iam/src/console_app/api/iam_ca_res_api.rs
+++ b/support/iam/src/console_app/api/iam_ca_res_api.rs
@@ -11,6 +11,7 @@ use crate::basic::serv::iam_set_serv::IamSetServ;
 use crate::iam_constants;
 use crate::iam_enumeration::{IamRelKind, IamSetKind};
 
+#[derive(Clone, Default)]
 pub struct IamCaResApi;
 
 /// App Console Res API

--- a/support/iam/src/console_app/api/iam_ca_role_api.rs
+++ b/support/iam/src/console_app/api/iam_ca_role_api.rs
@@ -18,6 +18,7 @@ use crate::iam_constants;
 use crate::iam_constants::RBUM_SCOPE_LEVEL_APP;
 use crate::iam_enumeration::{IamRelKind, IamRoleKind};
 
+#[derive(Clone, Default)]
 pub struct IamCaRoleApi;
 
 /// App Console Role API

--- a/support/iam/src/console_common/api/iam_cc_account_api.rs
+++ b/support/iam/src/console_common/api/iam_cc_account_api.rs
@@ -16,7 +16,9 @@ use crate::basic::serv::iam_cert_ldap_serv::IamCertLdapServ;
 use crate::iam_constants;
 use crate::iam_enumeration::IamRelKind;
 
+#[derive(Clone, Default)]
 pub struct IamCcAccountApi;
+#[derive(Clone, Default)]
 pub struct IamCcAccountLdapApi;
 
 /// Common Console Account API

--- a/support/iam/src/console_common/api/iam_cc_app_api.rs
+++ b/support/iam/src/console_common/api/iam_cc_app_api.rs
@@ -11,6 +11,7 @@ use crate::basic::dto::iam_filer_dto::IamAppFilterReq;
 use crate::basic::serv::iam_app_serv::IamAppServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCcAppApi;
 
 /// Common Console App API

--- a/support/iam/src/console_common/api/iam_cc_org_api.rs
+++ b/support/iam/src/console_common/api/iam_cc_org_api.rs
@@ -11,6 +11,7 @@ use bios_basic::rbum::rbum_enumeration::RbumSetCateLevelQueryKind;
 use crate::basic::serv::iam_set_serv::IamSetServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCcOrgApi;
 
 /// Common Console Org API

--- a/support/iam/src/console_common/api/iam_cc_res_api.rs
+++ b/support/iam/src/console_common/api/iam_cc_res_api.rs
@@ -13,6 +13,7 @@ use crate::basic::serv::iam_set_serv::IamSetServ;
 use crate::iam_constants;
 use crate::iam_enumeration::IamSetKind;
 
+#[derive(Clone, Default)]
 pub struct IamCcResApi;
 
 /// Common Console Res API

--- a/support/iam/src/console_common/api/iam_cc_role_api.rs
+++ b/support/iam/src/console_common/api/iam_cc_role_api.rs
@@ -14,6 +14,7 @@ use crate::basic::serv::iam_role_serv::IamRoleServ;
 use crate::iam_constants;
 use crate::iam_enumeration::IamRoleKind;
 
+#[derive(Clone, Default)]
 pub struct IamCcRoleApi;
 
 /// Common Console Role API

--- a/support/iam/src/console_common/api/iam_cc_system_api.rs
+++ b/support/iam/src/console_common/api/iam_cc_system_api.rs
@@ -6,6 +6,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisResp};
 use crate::iam_config::IamConfig;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCcSystemApi;
 
 /// Common Console System API

--- a/support/iam/src/console_common/api/iam_cc_tenant_api.rs
+++ b/support/iam/src/console_common/api/iam_cc_tenant_api.rs
@@ -6,6 +6,7 @@ use tardis::web::web_resp::{TardisApiResult, TardisResp};
 use crate::basic::serv::iam_tenant_serv::IamTenantServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCcTenantApi;
 
 /// Common Console Tenant API

--- a/support/iam/src/console_interface/api/iam_ci_account_api.rs
+++ b/support/iam/src/console_interface/api/iam_ci_account_api.rs
@@ -7,6 +7,7 @@ use tardis::TardisFuns;
 use crate::basic::serv::iam_key_cache_serv::IamIdentCacheServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCiAccountApi;
 
 /// Interface Console Account API

--- a/support/iam/src/console_interface/api/iam_ci_app_api.rs
+++ b/support/iam/src/console_interface/api/iam_ci_app_api.rs
@@ -9,6 +9,7 @@ use tardis::web::poem_openapi;
 use tardis::web::poem_openapi::payload::Json;
 use tardis::web::web_resp::{TardisApiResult, TardisResp};
 
+#[derive(Clone, Default)]
 pub struct IamCiAppApi;
 
 /// # Interface Console Manage Cert API

--- a/support/iam/src/console_interface/api/iam_ci_cert_api.rs
+++ b/support/iam/src/console_interface/api/iam_ci_cert_api.rs
@@ -16,8 +16,11 @@ use tardis::web::poem_openapi::param::{Path, Query};
 use tardis::web::poem_openapi::payload::Json;
 use tardis::web::web_resp::{TardisApiResult, TardisResp, Void};
 
+#[derive(Clone, Default)]
 pub struct IamCiCertManageApi;
+#[derive(Clone, Default)]
 pub struct IamCiCertApi;
+#[derive(Clone, Default)]
 pub struct IamCiLdapCertApi;
 
 /// # Interface Console Manage Cert API

--- a/support/iam/src/console_interface/api/iam_ci_res_api.rs
+++ b/support/iam/src/console_interface/api/iam_ci_res_api.rs
@@ -12,6 +12,7 @@ use tardis::web::poem_openapi::payload::Json;
 use tardis::web::web_resp::{TardisApiResult, TardisResp};
 use tardis::TardisFuns;
 
+#[derive(Clone, Default)]
 pub struct IamCiResApi;
 
 /// # Interface Console Manage Cert API

--- a/support/iam/src/console_interface/api/iam_ci_role_api.rs
+++ b/support/iam/src/console_interface/api/iam_ci_role_api.rs
@@ -6,6 +6,7 @@ use tardis::web::poem_openapi;
 use tardis::web::poem_openapi::param::Path;
 use tardis::web::web_resp::{TardisApiResult, TardisResp, Void};
 
+#[derive(Clone, Default)]
 pub struct IamCiRoleApi;
 
 /// # Interface Console Manage Cert API

--- a/support/iam/src/console_passport/api/iam_cp_account_api.rs
+++ b/support/iam/src/console_passport/api/iam_cp_account_api.rs
@@ -12,6 +12,7 @@ use crate::console_passport::dto::iam_cp_account_dto::IamCpAccountInfoResp;
 use crate::console_passport::serv::iam_cp_account_serv::IamCpAccountServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCpAccountApi;
 
 /// Passport Console Account API

--- a/support/iam/src/console_passport/api/iam_cp_app_api.rs
+++ b/support/iam/src/console_passport/api/iam_cp_app_api.rs
@@ -11,6 +11,7 @@ use tardis::web::poem_openapi;
 use tardis::web::poem_openapi::param::Query;
 use tardis::web::web_resp::{TardisApiResult, TardisPage, TardisResp};
 
+#[derive(Clone, Default)]
 pub struct IamCpAppApi;
 
 /// Passport Console App API

--- a/support/iam/src/console_passport/api/iam_cp_cert_api.rs
+++ b/support/iam/src/console_passport/api/iam_cp_cert_api.rs
@@ -36,7 +36,9 @@ use crate::console_passport::serv::iam_cp_cert_user_pwd_serv::IamCpCertUserPwdSe
 use crate::iam_constants;
 use crate::iam_enumeration::{IamCertKernelKind, IamCertOAuth2Supplier};
 
+#[derive(Clone, Default)]
 pub struct IamCpCertApi;
+#[derive(Clone, Default)]
 pub struct IamCpCertLdapApi;
 
 /// Passport Console Cert API

--- a/support/iam/src/console_passport/api/iam_cp_tenant_api.rs
+++ b/support/iam/src/console_passport/api/iam_cp_tenant_api.rs
@@ -10,6 +10,7 @@ use crate::basic::serv::iam_cert_serv::IamCertServ;
 use crate::basic::serv::iam_tenant_serv::IamTenantServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCpTenantApi;
 
 /// Passport Console Tenant API

--- a/support/iam/src/console_system/api/iam_cs_account_api.rs
+++ b/support/iam/src/console_system/api/iam_cs_account_api.rs
@@ -21,6 +21,7 @@ use crate::basic::serv::iam_set_serv::IamSetServ;
 use crate::iam_constants;
 use crate::iam_enumeration::{IamAccountLockStateKind, IamAccountStatusKind, IamRelKind};
 
+#[derive(Clone, Default)]
 pub struct IamCsAccountApi;
 
 /// System Console Account API

--- a/support/iam/src/console_system/api/iam_cs_account_attr_api.rs
+++ b/support/iam/src/console_system/api/iam_cs_account_attr_api.rs
@@ -12,6 +12,7 @@ use crate::basic::serv::iam_attr_serv::IamAttrServ;
 use crate::basic::serv::iam_cert_serv::IamCertServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCsAccountAttrApi;
 
 /// System Console Account Attr API

--- a/support/iam/src/console_system/api/iam_cs_cert_api.rs
+++ b/support/iam/src/console_system/api/iam_cs_cert_api.rs
@@ -18,6 +18,7 @@ use crate::basic::serv::iam_cert_user_pwd_serv::IamCertUserPwdServ;
 use crate::iam_constants;
 use crate::iam_enumeration::{IamCertExtKind, IamCertKernelKind};
 
+#[derive(Clone, Default)]
 pub struct IamCsCertApi;
 
 /// System Console Cert API
@@ -148,6 +149,7 @@ impl IamCsCertApi {
     }
 }
 
+#[derive(Clone, Default)]
 pub struct IamCsCertConfigLdapApi;
 /// System Console Cert Config LDAP API
 #[cfg(feature = "ldap_client")]

--- a/support/iam/src/console_system/api/iam_cs_org_api.rs
+++ b/support/iam/src/console_system/api/iam_cs_org_api.rs
@@ -15,7 +15,9 @@ use tardis::web::poem_openapi;
 use tardis::web::poem_openapi::{param::Path, param::Query, payload::Json};
 use tardis::web::web_resp::{TardisApiResult, TardisResp, Void};
 
+#[derive(Clone, Default)]
 pub struct IamCsOrgApi;
+#[derive(Clone, Default)]
 pub struct IamCsOrgItemApi;
 
 /// System Console Org API

--- a/support/iam/src/console_system/api/iam_cs_platform_api.rs
+++ b/support/iam/src/console_system/api/iam_cs_platform_api.rs
@@ -7,6 +7,7 @@ use crate::basic::dto::iam_platform_dto::{IamPlatformConfigReq, IamPlatformConfi
 use crate::basic::serv::iam_platform_serv::IamPlatformServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCsPlatformApi;
 
 /// System Console Platform API

--- a/support/iam/src/console_system/api/iam_cs_res_api.rs
+++ b/support/iam/src/console_system/api/iam_cs_res_api.rs
@@ -19,6 +19,7 @@ use crate::basic::serv::iam_set_serv::IamSetServ;
 use crate::iam_constants;
 use crate::iam_enumeration::{IamRelKind, IamResKind, IamSetKind};
 
+#[derive(Clone, Default)]
 pub struct IamCsResApi;
 
 /// System Console Res API

--- a/support/iam/src/console_system/api/iam_cs_role_api.rs
+++ b/support/iam/src/console_system/api/iam_cs_role_api.rs
@@ -14,6 +14,7 @@ use crate::basic::serv::iam_role_serv::IamRoleServ;
 use crate::iam_constants;
 use crate::iam_enumeration::IamRoleKind;
 
+#[derive(Clone, Default)]
 pub struct IamCsRoleApi;
 
 /// System Console Role API

--- a/support/iam/src/console_system/api/iam_cs_spi_data_api.rs
+++ b/support/iam/src/console_system/api/iam_cs_spi_data_api.rs
@@ -17,6 +17,7 @@ use crate::basic::serv::iam_tenant_serv::IamTenantServ;
 use crate::iam_config::IamConfig;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCsSpiDataApi;
 
 /// System Console Tenant API

--- a/support/iam/src/console_system/api/iam_cs_tenant_api.rs
+++ b/support/iam/src/console_system/api/iam_cs_tenant_api.rs
@@ -12,6 +12,7 @@ use crate::iam_constants;
 use bios_basic::rbum::dto::rbum_filer_dto::RbumBasicFilterReq;
 use bios_basic::rbum::serv::rbum_item_serv::RbumItemCrudOperation;
 
+#[derive(Clone, Default)]
 pub struct IamCsTenantApi;
 
 /// System Console Tenant API

--- a/support/iam/src/console_tenant/api/iam_ct_account_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_account_api.rs
@@ -16,6 +16,7 @@ use crate::basic::serv::iam_cert_serv::IamCertServ;
 use crate::basic::serv::iam_set_serv::IamSetServ;
 use crate::iam_constants;
 use crate::iam_enumeration::{IamAccountLockStateKind, IamAccountStatusKind, IamRelKind};
+#[derive(Clone, Default)]
 pub struct IamCtAccountApi;
 
 /// Tenant Console Account API

--- a/support/iam/src/console_tenant/api/iam_ct_account_attr_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_account_attr_api.rs
@@ -11,6 +11,7 @@ use crate::basic::dto::iam_attr_dto::IamKindAttrAddReq;
 use crate::basic::serv::iam_attr_serv::IamAttrServ;
 use crate::iam_constants;
 
+#[derive(Clone, Default)]
 pub struct IamCtAccountAttrApi;
 
 /// Tenant Console Account Attr API

--- a/support/iam/src/console_tenant/api/iam_ct_app_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_app_api.rs
@@ -11,6 +11,7 @@ use crate::basic::dto::iam_app_dto::{IamAppAggAddReq, IamAppDetailResp, IamAppMo
 use crate::basic::dto::iam_filer_dto::IamAppFilterReq;
 use crate::basic::serv::iam_app_serv::IamAppServ;
 use crate::iam_constants;
+#[derive(Clone, Default)]
 pub struct IamCtAppApi;
 
 /// Tenant Console App API

--- a/support/iam/src/console_tenant/api/iam_ct_app_set_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_app_set_api.rs
@@ -13,6 +13,7 @@ use crate::basic::serv::iam_cert_serv::IamCertServ;
 use crate::basic::serv::iam_set_serv::IamSetServ;
 use crate::iam_constants;
 use crate::iam_enumeration::IamSetKind;
+#[derive(Clone, Default)]
 pub struct IamCtAppSetApi;
 
 /// Tenant Console App Set API

--- a/support/iam/src/console_tenant/api/iam_ct_cert_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_cert_api.rs
@@ -12,6 +12,7 @@ use crate::basic::serv::iam_cert_serv::IamCertServ;
 use crate::basic::serv::iam_cert_user_pwd_serv::IamCertUserPwdServ;
 use crate::iam_constants;
 use crate::iam_enumeration::IamCertKernelKind;
+#[derive(Clone, Default)]
 pub struct IamCtCertApi;
 
 /// Tenant Console Cert API

--- a/support/iam/src/console_tenant/api/iam_ct_cert_manage_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_cert_manage_api.rs
@@ -12,6 +12,7 @@ use crate::basic::dto::iam_cert_dto::{IamCertManageAddReq, IamCertManageModifyRe
 use crate::basic::serv::iam_cert_serv::IamCertServ;
 use crate::iam_constants;
 use crate::iam_enumeration::IamCertExtKind;
+#[derive(Clone, Default)]
 pub struct IamCtCertManageApi;
 
 /// Tenant Console Cert manage API

--- a/support/iam/src/console_tenant/api/iam_ct_org_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_org_api.rs
@@ -15,6 +15,7 @@ use crate::basic::dto::iam_set_dto::{IamSetCateAddReq, IamSetCateModifyReq, IamS
 use crate::basic::serv::iam_set_serv::IamSetServ;
 use crate::iam_constants;
 use crate::iam_enumeration::{IamRelKind, IamSetKind};
+#[derive(Clone, Default)]
 pub struct IamCtOrgApi;
 
 /// Tenant Console Org API

--- a/support/iam/src/console_tenant/api/iam_ct_res_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_res_api.rs
@@ -10,6 +10,7 @@ use crate::basic::serv::iam_res_serv::IamResServ;
 use crate::basic::serv::iam_set_serv::IamSetServ;
 use crate::iam_constants;
 use crate::iam_enumeration::{IamRelKind, IamSetKind};
+#[derive(Clone, Default)]
 pub struct IamCtResApi;
 
 /// Tenant Console Res API

--- a/support/iam/src/console_tenant/api/iam_ct_role_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_role_api.rs
@@ -15,6 +15,7 @@ use crate::basic::serv::iam_role_serv::IamRoleServ;
 use crate::iam_constants;
 use crate::iam_constants::RBUM_SCOPE_LEVEL_TENANT;
 use crate::iam_enumeration::IamRoleKind;
+#[derive(Clone, Default)]
 pub struct IamCtRoleApi;
 
 /// Tenant Console Role API

--- a/support/iam/src/console_tenant/api/iam_ct_tenant_api.rs
+++ b/support/iam/src/console_tenant/api/iam_ct_tenant_api.rs
@@ -8,6 +8,7 @@ use crate::basic::dto::iam_filer_dto::IamTenantFilterReq;
 use crate::basic::dto::iam_tenant_dto::{IamTenantAggDetailResp, IamTenantAggModifyReq, IamTenantConfigReq, IamTenantConfigResp};
 use crate::basic::serv::iam_tenant_serv::IamTenantServ;
 use crate::iam_constants;
+#[derive(Clone, Default)]
 pub struct IamCtTenantApi;
 
 /// Tenant Console Tenant API

--- a/support/iam/src/iam_initializer.rs
+++ b/support/iam/src/iam_initializer.rs
@@ -5,7 +5,7 @@ use tardis::basic::result::TardisResult;
 use tardis::db::reldb_client::TardisActiveModel;
 use tardis::db::sea_orm::sea_query::Table;
 use tardis::log::info;
-use tardis::web::web_server::TardisWebServer;
+use tardis::web::web_server::{TardisWebServer, WebServerModule};
 use tardis::{TardisFuns, TardisFunsInst};
 
 use bios_basic::rbum::dto::rbum_domain_dto::RbumDomainAddReq;
@@ -56,7 +56,7 @@ async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
     web_server
         .add_module(
             iam_constants::COMPONENT_CODE,
-            (
+            WebServerModule::from((
                 (
                     iam_cc_account_api::IamCcAccountApi,
                     iam_cc_app_api::IamCcAppApi,
@@ -117,8 +117,8 @@ async fn init_api(web_server: &TardisWebServer) -> TardisResult<()> {
                     iam_ci_role_api::IamCiRoleApi,
                     iam_ci_account_api::IamCiAccountApi,
                 ),
-            ),
-            vec![EncryptMW::boxed()],
+            ))
+            .middleware(EncryptMW),
         )
         .await;
     Ok(())


### PR DESCRIPTION
1. derive `Clone` for all api struct
2. modify usage of `web_server.add_module`
3. add support for nacos/v2 api