### PR TITLE
Global: Fix length limit

### DIFF
--- a/spi/spi-conf/src/dto/conf_auth_dto.rs
+++ b/spi/spi-conf/src/dto/conf_auth_dto.rs
@@ -18,7 +18,7 @@ impl RegisterResponse {
 
 #[derive(Debug, Serialize, Deserialize, poem_openapi::Object, Default)]
 pub struct RegisterRequest {
-    #[oai(validator(pattern = r"^[a-zA-Z\d_]{6,16}$"))]
+    #[oai(validator(pattern = r"^[a-zA-Z\d_]{5,16}$"))]
     pub username: Option<TrimString>,
     #[oai(validator(pattern = r"^[a-zA-Z\d~!@#$%^&*\(\)_+]{8,16}$"))]
     pub password: Option<TrimString>,

--- a/spi/spi-conf/src/serv/pg/conf_pg_initializer.rs
+++ b/spi/spi-conf/src/serv/pg/conf_pg_initializer.rs
@@ -61,7 +61,7 @@ created_time timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
 modified_time timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
 tp character varying"#
         ),
-        vec![("data_id", "btree"), ("grp", "btree"), ("namespace_id", "btree"), ("md5", "btree"), ("app_name", "btree")],
+        vec![("data_id", "btree"), ("grp", "btree"), ("md5", "btree"), ("app_name", "btree")],
         None,
         Some("modified_time"),
     )
@@ -97,7 +97,7 @@ op_type character(1) NOT NULL DEFAULT 'I',
 config_tags text NOT NULL DEFAULT '',
 tp character varying"#
         ),
-        vec![("data_id", "btree"), ("grp", "btree"), ("namespace_id", "btree"), ("md5", "btree"), ("app_name", "btree")],
+        vec![("data_id", "btree"), ("grp", "btree"), ("md5", "btree"), ("app_name", "btree")],
         None,
         Some("modified_time"),
     )
@@ -126,7 +126,7 @@ pub async fn init_table_and_conn_tag_config_rel(
 tag_id character varying NOT NULL REFERENCES {tag_table_name} ON DELETE CASCADE,
 config_id uuid NOT NULL REFERENCES {config_table_name} ON DELETE CASCADE"#
         ),
-        vec![("tag_id", "btree"), ("config_id", "btree")],
+        vec![],
         None,
         None,
     )

--- a/spi/spi-log/src/dto/log_item_dto.rs
+++ b/spi/spi-log/src/dto/log_item_dto.rs
@@ -25,7 +25,6 @@ pub struct LogItemAddReq {
     pub ts: Option<DateTime<Utc>>,
     #[oai(validator(min_length = "2"))]
     pub owner: Option<String>,
-    #[oai(validator(min_length = "2"))]
     pub own_paths: Option<String>,
 }
 


### PR DESCRIPTION
1. [remove owner path length limit for spi-log](https://github.com/ideal-world/bios/commit/5294283ad55584fe54d98da0242176be8729b5b7)
2. [spi-conf: change username length limit to 5~16 spi-conf](https://github.com/ideal-world/bios/commit/0e0cf3bd41da9d7f1fda55e5ed8696989ec12111), support username like `nacos`
3. remove duplicated db index