### PR TITLE
spi-conf: fix: different node hold it's own auth key and cache

### DIFF
--- a/spi/spi-conf/src/conf_config.rs
+++ b/spi/spi-conf/src/conf_config.rs
@@ -9,6 +9,7 @@ pub struct ConfConfig {
     pub rbum: RbumConfig,
     /// token ttl in second, default as 18000
     pub token_ttl: u32,
+    /// this should be specified when we have multi nodes.
     pub auth_key: String,
     pub auth_username: String,
     pub auth_password: String,
@@ -29,9 +30,8 @@ impl Default for ConfConfig {
     fn default() -> Self {
         use tardis::crypto::*;
         use tardis::rand::*;
-        let auth_key = crypto_base64::TardisCryptoBase64.encode(format!("{:016x}", random::<u128>()));
+        let auth_key = crypto_base64::TardisCryptoBase64.encode(random::<[u8; 32]>());
         let password = format!("{:016x}", random::<u128>());
-
         Self {
             /// 18000 secs (5 hours)
             token_ttl: 18000,
@@ -41,7 +41,7 @@ impl Default for ConfConfig {
             rbum: Default::default(),
             nacos_port: 8848,
             nacos_grpc_port: 9848,
-            nacos_host: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            nacos_host: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
         }
     }
 }

--- a/spi/spi-conf/src/conf_constants.rs
+++ b/spi/spi-conf/src/conf_constants.rs
@@ -20,6 +20,7 @@ pub mod error {
             CONLICT_AK:                 409 = "conlict-username";
             EXCEED_MAX_RETRY_TIMES:           409 = "exceed-max-retry-times";
             VALID_ERROR:                401 = "valid-error";
+            CACHE_ERROR:                500 = "cache-error";
         }
     }
 }

--- a/spi/spi-conf/src/conf_initializer.rs
+++ b/spi/spi-conf/src/conf_initializer.rs
@@ -59,3 +59,12 @@ pub async fn init_admin_cert(funs: &TardisFunsInst, ctx: &TardisContext) {
 pub(crate) fn get_tardis_inst() -> TardisFunsInst {
     TardisFuns::inst_with_db_conn(DOMAIN_CODE.to_string(), None)
 }
+
+#[inline]
+pub(crate) fn get_tardis_inst_ref() -> &'static TardisFunsInst {
+    use std::sync::OnceLock;
+    static INST: OnceLock<TardisFunsInst> = OnceLock::new();
+    INST.get_or_init(|| {
+        TardisFuns::inst_with_db_conn(DOMAIN_CODE.to_string(), None)
+    })
+}

--- a/spi/spi-conf/src/lib.rs
+++ b/spi/spi-conf/src/lib.rs
@@ -6,6 +6,7 @@ pub mod conf_config;
 pub mod conf_constants;
 pub mod conf_initializer;
 pub(crate) use crate::conf_initializer::get_tardis_inst;
+pub(crate) use crate::conf_initializer::get_tardis_inst_ref;
 pub mod dto;
 mod serv;
 mod utils;


### PR DESCRIPTION
Now use the cache provided by tardis, which is redis currently, instead of in-memory cache.