### PR TITLE
spi-conf: support modify sk's visibility from ca interface

### DIFF
--- a/spi/spi-conf/src/api/ci/conf_auth.rs
+++ b/spi/spi-conf/src/api/ci/conf_auth.rs
@@ -87,10 +87,10 @@ impl ConfCiAuthApi {
                 .ok_or_else(|| funs.err().not_found(&SpiBsServ::get_obj_name(), "register", "not found backend service", "404-spi-bs-not-exist"))?;
                 bs.id
             }
-            BackendServiceSource::New { name, kind_code } => {
+            BackendServiceSource::New { name } => {
                 // #TODO
                 // this should be determined by url, but now we only support spi-pg
-                let kind_code = kind_code.unwrap_or(spi_constants::SPI_PG_KIND_CODE.to_string());
+                let kind_code = spi_constants::SPI_PG_KIND_CODE.to_string();
                 let kind_id = RbumKindServ::get_rbum_kind_id_by_code(&kind_code, &funs)
                     .await?
                     .ok_or_else(|| funs.err().not_found(&SpiBsServ::get_obj_name(), "register", "db spi kind not found", "404-spi-bs-not-exist"))?;

--- a/spi/spi-conf/src/api/ci/conf_auth.rs
+++ b/spi/spi-conf/src/api/ci/conf_auth.rs
@@ -16,7 +16,6 @@ use bios_basic::{
 };
 use poem::web::RealIp;
 use tardis::{
-    basic::error::TardisError,
     serde_json,
     web::{
         context_extractor::TardisContextExtractor,
@@ -88,31 +87,29 @@ impl ConfCiAuthApi {
                 .ok_or_else(|| funs.err().not_found(&SpiBsServ::get_obj_name(), "register", "not found backend service", "404-spi-bs-not-exist"))?;
                 bs.id
             }
-            BackendServiceSource::New { name, conn_uri, kind_code } => {
+            BackendServiceSource::New { name, kind_code } => {
                 // #TODO
                 // this should be determined by url, but now we only support spi-pg
                 let kind_code = kind_code.unwrap_or(spi_constants::SPI_PG_KIND_CODE.to_string());
                 let kind_id = RbumKindServ::get_rbum_kind_id_by_code(&kind_code, &funs)
                     .await?
                     .ok_or_else(|| funs.err().not_found(&SpiBsServ::get_obj_name(), "register", "db spi kind not found", "404-spi-bs-not-exist"))?;
-                let conn_uri = conn_uri.parse::<Url>().map_err(|_| TardisError::bad_request("invalid conn url", "400-spi_conf-bad-request"))?;
-                let ak = conn_uri.username();
-                let sk = conn_uri.password().unwrap_or("");
-                SpiBsServ::add_item(
-                    &mut SpiBsAddReq {
-                        name: name.into(),
-                        conn_uri: conn_uri.to_string(),
-                        ext: "{\"max_connections\":20,\"min_connections\":10}".to_string(),
-                        private: false,
-                        disabled: None,
-                        ak: ak.into(),
-                        sk: sk.into(),
-                        kind_id: kind_id.into(),
-                    },
-                    &funs,
-                    &default_ctx,
-                )
-                .await?
+                let conn_uri = tardis::TardisFuns::fw_config().db().default.url.clone();
+                let mut req = SpiBsAddReq {
+                    name: name.unwrap_or(format!("spi-conf-{}", tardis::crypto::crypto_key::TardisCryptoKey.rand_8_hex())).into(),
+                    conn_uri: conn_uri.to_string(),
+                    ext: "{\"max_connections\":20,\"min_connections\":10}".to_string(),
+                    private: false,
+                    disabled: None,
+                    ak: "".into(),
+                    sk: "".into(),
+                    kind_id: kind_id.into(),
+                };
+                if let Ok(conn_uri) = Url::parse(&conn_uri) {
+                    req.ak = conn_uri.username().into();
+                    req.sk = conn_uri.password().unwrap_or("").into();
+                }
+                SpiBsServ::add_item(&mut req, &funs, &default_ctx).await?
             }
         };
         let app_tenant_id = req.app_tenant_id.as_deref().unwrap_or(ctx.owner.as_str());

--- a/spi/spi-conf/src/dto/conf_auth_dto.rs
+++ b/spi/spi-conf/src/dto/conf_auth_dto.rs
@@ -73,8 +73,8 @@ pub enum BackendServiceSource {
     #[default]
     Default,
     New {
-        name: String,
-        conn_uri: String,
+        name: Option<String>,
+        // conn_uri: String,
         //
         kind_code: Option<String>,
     },

--- a/spi/spi-conf/src/dto/conf_auth_dto.rs
+++ b/spi/spi-conf/src/dto/conf_auth_dto.rs
@@ -76,7 +76,7 @@ pub enum BackendServiceSource {
         name: Option<String>,
         // conn_uri: String,
         //
-        kind_code: Option<String>,
+        // kind_code: Option<String>,
     },
 }
 

--- a/support/iam/src/basic/dto/iam_cert_dto.rs
+++ b/support/iam/src/basic/dto/iam_cert_dto.rs
@@ -221,3 +221,8 @@ pub struct IamOauth2AkSkResp {
 pub struct IamCertDecodeRequest {
     pub codes: HashSet<String>,
 }
+
+#[derive(poem_openapi::Object, Serialize, Deserialize, Debug)]
+pub struct IamCertModifyVisibilityRequest {
+    pub sk_invisible: bool,
+}

--- a/support/iam/src/console_app/api/iam_ca_cert_manage_api.rs
+++ b/support/iam/src/console_app/api/iam_ca_cert_manage_api.rs
@@ -1,11 +1,12 @@
 use tardis::web::context_extractor::TardisContextExtractor;
 use tardis::web::poem_openapi;
-use tardis::web::poem_openapi::param::Path;
-use tardis::web::web_resp::{TardisApiResult, TardisResp};
+use tardis::web::poem_openapi::{param::Path, payload::Json};
+use tardis::web::web_resp::{TardisApiResult, TardisResp, Void};
 
 use bios_basic::rbum::dto::rbum_cert_dto::RbumCertSummaryWithSkResp;
 use bios_basic::rbum::dto::rbum_rel_dto::RbumRelBoneResp;
 
+use crate::basic::dto::iam_cert_dto::IamCertModifyVisibilityRequest;
 use crate::basic::serv::iam_cert_serv::IamCertServ;
 use crate::iam_constants;
 use bios_basic::helper::request_helper::add_remote_ip;
@@ -25,6 +26,17 @@ impl IamCaCertManageApi {
         let cert = IamCertServ::get_3th_kind_cert_by_id(&id.0, &funs, &ctx).await?;
         ctx.execute_task().await?;
         TardisResp::ok(cert)
+    }
+
+    /// get manage cert
+    #[oai(path = "/:id", method = "put")]
+    async fn modify_sk_visibility(&self, id: Path<String>, body: Json<IamCertModifyVisibilityRequest>, ctx: TardisContextExtractor, request: &Request) -> TardisApiResult<Void> {
+        add_remote_ip(request, &ctx.0).await?;
+        let funs = iam_constants::get_tardis_inst();
+        let ctx = IamCertServ::use_sys_or_tenant_ctx_unsafe(ctx.0)?;
+        IamCertServ::modify_sk_visibility(&id.0, body.0, &funs, &ctx).await?;
+        ctx.execute_task().await?;
+        TardisResp::ok(Void)
     }
 
     /// Find Manage Certs By item Id


### PR DESCRIPTION
1. support modify sk's visibility from ca interface
2. use bios's backend db as spi-conf's database